### PR TITLE
Agregar estadísticas de búsqueda y numeración 1-based

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,13 +323,13 @@
             <p>Este solucionador utiliza BFS para encontrar la solución óptima al puzle lineal de 8 dígitos. Los movimientos disponibles son intercambios entre posiciones adyacentes:</p>
             
             <div class="movements-grid">
-                <div class="movement-item"><strong>M1:</strong> Intercambia posiciones 0 ↔ 1</div>
-                <div class="movement-item"><strong>M2:</strong> Intercambia posiciones 1 ↔ 2</div>
-                <div class="movement-item"><strong>M3:</strong> Intercambia posiciones 2 ↔ 3</div>
-                <div class="movement-item"><strong>M4:</strong> Intercambia posiciones 3 ↔ 4</div>
-                <div class="movement-item"><strong>M5:</strong> Intercambia posiciones 4 ↔ 5</div>
-                <div class="movement-item"><strong>M6:</strong> Intercambia posiciones 5 ↔ 6</div>
-                <div class="movement-item"><strong>M7:</strong> Intercambia posiciones 6 ↔ 7</div>
+                <div class="movement-item"><strong>M1:</strong> Intercambia posiciones 1 ↔ 2</div>
+                <div class="movement-item"><strong>M2:</strong> Intercambia posiciones 2 ↔ 3</div>
+                <div class="movement-item"><strong>M3:</strong> Intercambia posiciones 3 ↔ 4</div>
+                <div class="movement-item"><strong>M4:</strong> Intercambia posiciones 4 ↔ 5</div>
+                <div class="movement-item"><strong>M5:</strong> Intercambia posiciones 5 ↔ 6</div>
+                <div class="movement-item"><strong>M6:</strong> Intercambia posiciones 6 ↔ 7</div>
+                <div class="movement-item"><strong>M7:</strong> Intercambia posiciones 7 ↔ 8</div>
             </div>
         </div>
         

--- a/js/app.js
+++ b/js/app.js
@@ -47,9 +47,9 @@ function showStats({ pasos, nodosExplorados, iteraciones }) {
 }
 
 /** Texto de movimiento legible */
-function movementLabel(move) {
+function etiquetaMovimiento(move) {
   if (!move) return '';
-  return `swap(${move.i},${move.j})  Pos ${move.i}↔${move.j}`;
+  return `intercambio(${move.i},${move.j})  Pos ${move.i}↔${move.j}`;
 }
 
 /** Valida que ambos estados tengan longitud 8 y mismo multiconjunto */
@@ -95,10 +95,10 @@ function solvePuzzle() {
       const t1 = performance.now();
 
       // Construir salida visual
-      const { pasos, camino, movimientos } = res;
+      const { pasos, camino, movimientos, nodosExplorados, iteraciones } = res;
 
-      // Estadísticas mínimas (tiempo medido en cliente)
-      showStats({ pasos, nodosExplorados: undefined, iteraciones: undefined });
+      // Estadísticas del algoritmo
+      showStats({ pasos, nodosExplorados, iteraciones });
 
       let html = '<div class="success-message">¡Solución encontrada!</div>';
       html += '<div class="solution-container">';
@@ -111,7 +111,7 @@ function solvePuzzle() {
         html += `
           <div class="step">
             <div class="step-number">${i}</div>
-            <div class="movement-info">${movementLabel(mov)}</div>
+            <div class="movement-info">${etiquetaMovimiento(mov)}</div>
             <div class="puzzle">${estado.map((n) => `<div class="tile">${n}</div>`).join('')}</div>
           </div>`;
       }

--- a/js/bfs.js
+++ b/js/bfs.js
@@ -2,7 +2,7 @@
 // Lógica del puzle lineal de 8 dígitos usando BFS (búsqueda no informada)
 // - Estados representados como arrays de longitud 8: [1,2,3,4,5,6,7,8]
 // - Acción: intercambiar elementos adyacentes (i, i+1)
-// - Retorna solución óptima en número de swaps adyacentes
+// - Retorna solución óptima en número de intercambios adyacentes
 
 /**
  * Genera vecinos intercambiando pares adyacentes.
@@ -14,9 +14,9 @@ export function vecinos(state) {
   for (let i = 0; i < state.length - 1; i++) {
     const next = state.slice();
     const j = i + 1;
-    // swap adyacente
+    // intercambio adyacente
     [next[i], next[j]] = [next[j], next[i]];
-    res.push({ next, move: { i, j } });
+    res.push({ next, move: { i: i + 1, j: j + 1 } });
   }
   return res;
 }
@@ -44,7 +44,7 @@ function reconstruirCamino(padres, goalKey, estados) {
 }
 
 /**
- * BFS que encuentra el camino óptimo de swaps adyacentes.
+ * BFS que encuentra el camino óptimo de intercambios adyacentes.
  * @param {number[]} inicio array de 8 números
  * @param {number[]} meta array de 8 números
  * @returns {{pasos:number, camino:number[][], movimientos:{i:number,j:number}[]}}
@@ -52,7 +52,8 @@ function reconstruirCamino(padres, goalKey, estados) {
 export function bfsLinear(inicio, meta) {
   const startKey = inicio.join(',');
   const goalKey = meta.join(',');
-  if (startKey === goalKey) return { pasos: 0, camino: [inicio.slice()], movimientos: [] };
+  if (startKey === goalKey)
+    return { pasos: 0, camino: [inicio.slice()], movimientos: [], nodosExplorados: 1, iteraciones: 0 };
 
   // Estructuras BFS
   const q = [inicio.slice()];
@@ -60,8 +61,13 @@ export function bfsLinear(inicio, meta) {
   const padres = new Map([[startKey, { parent: null, move: null }]]);
   const estados = new Map([[startKey, inicio.slice()]]);
 
+  let nodosExplorados = 0;
+  let iteraciones = 0;
+
   while (q.length) {
     const estado = q.shift();
+    nodosExplorados++;
+    iteraciones++;
     const vecinosList = vecinos(estado);
     for (const { next, move } of vecinosList) {
       const k = next.join(',');
@@ -70,7 +76,8 @@ export function bfsLinear(inicio, meta) {
       padres.set(k, { parent: estado.join(','), move });
       estados.set(k, next);
       if (k === goalKey) {
-        return reconstruirCamino(padres, k, estados);
+        const res = reconstruirCamino(padres, k, estados);
+        return { ...res, nodosExplorados, iteraciones };
       }
       q.push(next);
     }


### PR DESCRIPTION
## Resumen
- Mostrar nodos explorados e iteraciones en la búsqueda BFS del puzzle de 8 dígitos
- Ajustar la numeración de movimientos a base 1 y renombrar "swap" por "intercambio"
- Actualizar interfaz web para reflejar estadísticas y nueva terminología

## Pruebas
- `python bfs_linear_puzzle.py --start 12345678 --goal 87654321 --show-path`
- `node -e "import('./js/bfs.js').then(m=>{const r=m.bfsLinear([2,1,3,4,5,6,7,8],[1,2,3,4,5,6,7,8]); console.log('pasos',r.pasos,'nodos',r.nodosExplorados,'iter',r.iteraciones);})"`


------
https://chatgpt.com/codex/tasks/task_e_68b084fc7fa88331b57ad92f9be29344