### PR TITLE
Highlight swapped positions in puzzle steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
             margin: 2px;
         }
+
+        .tile.swapped {
+            background: linear-gradient(45deg, #4CAF50, #45a049);
+        }
         
         .tile:hover {
             transform: translateY(-2px);

--- a/js/app.js
+++ b/js/app.js
@@ -108,11 +108,19 @@ function solvePuzzle() {
       for (let i = 1; i < camino.length; i++) {
         const estado = camino[i];
         const mov = movimientos[i - 1];
+        const puzzleHtml = estado
+          .map((n, idx) => {
+            const pos = idx + 1;
+            const swapped = mov && (pos === mov.i || pos === mov.j);
+            const extraClass = swapped ? ' swapped' : '';
+            return `<div class="tile${extraClass}">${n}</div>`;
+          })
+          .join('');
         html += `
           <div class="step">
             <div class="step-number">${i}</div>
             <div class="movement-info">${etiquetaMovimiento(mov)}</div>
-            <div class="puzzle">${estado.map((n) => `<div class="tile">${n}</div>`).join('')}</div>
+            <div class="puzzle">${puzzleHtml}</div>
           </div>`;
       }
       html += '</div>';


### PR DESCRIPTION
## Summary
- Resaltar con color los números intercambiados en cada paso de la solución.
- Añadir estilos CSS para los tiles resaltados.

## Testing
- `node js/app.js` *(ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c3d3eb2c83318d28f5815d597550